### PR TITLE
Typo: conversation to conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,8 @@
 	</div>
 
 	<div class="col-lg-3">
-		<h3>Type Conversation</h3>
-		<p>Automatic and safe type conversation between Cassandra and Go without
+		<h3>Type Conversion</h3>
+		<p>Automatic and safe type conversion between Cassandra and Go without
 		any loss of precision. Basic types, collections and UUIDs are supported
 		by default and custom types can implement their own marshaling logic.</p>
 	</div>


### PR DESCRIPTION
Given the context, conversion seems like a better term here.
